### PR TITLE
ipfs pinning of each acquired manuscript

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -11,7 +11,7 @@ App = {
       for (i = 0; i < data.length; i ++) {
         // Pin the data locally to speed up loading and future network distribution
         // We can change this last part to be ...=/ipfs/"+data[i].corpusID"/recursive=true
-        $.get("http://localhost:5001/api/v0/pin/add?arg=/ipns/"+data[i].submitter+"/"+data[i].doi"/recursive=true") 
+        $.get("http://localhost:5001/api/v0/pin/add?arg=/ipns/"+data[i].submitter+"/"+data[i].doi"/&recursive=true");
         
         articleTemplate.find('.article-title').text(data[i].title);        
         articleTemplate.find('.article-title').attr('href', "http://localhost:8080/ipns/"+data[i].submitter+"/"+data[i].doi+"/"+data[i].doi+".pdf")

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9,7 +9,11 @@ App = {
       var articleTemplate = $('#articleTemplate');
 
       for (i = 0; i < data.length; i ++) {
-        articleTemplate.find('.article-title').text(data[i].title);
+        // Pin the data locally to speed up loading and future network distribution
+        // We can change this last part to be ...=/ipfs/"+data[i].corpusID"/recursive=true
+        $.get("http://localhost:5001/api/v0/pin/add?arg=/ipns/"+data[i].submitter+"/"+data[i].doi"/recursive=true") 
+        
+        articleTemplate.find('.article-title').text(data[i].title);        
         articleTemplate.find('.article-title').attr('href', "http://localhost:8080/ipns/"+data[i].submitter+"/"+data[i].doi+"/"+data[i].doi+".pdf")
         articleTemplate.find('.article-authors').text(data[i].authors);
         articleTemplate.find('.article-submitter').text(data[i].submitter);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -14,7 +14,7 @@ App = {
         $.get("http://localhost:5001/api/v0/pin/add?arg=/ipns/"+data[i].submitter+"/"+data[i].doi"/&recursive=true");
         
         articleTemplate.find('.article-title').text(data[i].title);        
-        articleTemplate.find('.article-title').attr('href', "http://localhost:8080/ipns/"+data[i].submitter+"/"+data[i].doi+"/"+data[i].doi+".pdf")
+        articleTemplate.find('.article-title').attr('href', "http://localhost:8080/ipns/"+data[i].submitter+"/"+data[i].doi+"/"+data[i].doi+".pdf");
         articleTemplate.find('.article-authors').text(data[i].authors);
         articleTemplate.find('.article-submitter').text(data[i].submitter);
         articleTemplate.find('.article-tags').text(data[i].tags);


### PR DESCRIPTION
This will cause IPFS to pin (store locally and permanently, which helps keep the files "liquid") each manuscript it finds. Allows us to say that this subnet of IPFS is keeping a healthy distribution of the files. 